### PR TITLE
Add env OPENAI_API_URL for other OpenAI compatible api url

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,12 @@ func main() {
 		openAiModel = model
 	}
 
-	response, err := queryOpenAI(openAIKey, openAiModel, prompt(cmd), 1000)
+	openAIUrl, ok := os.LookupEnv("OPENAI_API_URL")
+	if !ok {
+		openAIUrl = "https://api.openai.com/v1/chat/completions"
+	}
+
+	response, err := queryOpenAI(openAIUrl, openAIKey, openAiModel, prompt(cmd), 1000)
 	if err != nil {
 		panic(err)
 	}

--- a/openai.go
+++ b/openai.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 )
 
-const openAIEndpoint = "https://api.openai.com/v1/chat/completions"
-
 type OpenAIRequest struct {
 	Model     string    `json:"model"`
 	Messages  []Message `json:"messages"`
@@ -27,7 +25,7 @@ type OpenAIResponse struct {
 	} `json:"choices"`
 }
 
-func queryOpenAI(apiKey, model, prompt string, maxTokens int) (string, error) {
+func queryOpenAI(apiUrl, apiKey, model, prompt string, maxTokens int) (string, error) {
 	requestBody := OpenAIRequest{
 		Model:     model,
 		Messages:  []Message{{Role: "user", Content: prompt}},
@@ -39,7 +37,7 @@ func queryOpenAI(apiKey, model, prompt string, maxTokens int) (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", openAIEndpoint, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("POST", apiUrl, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION

Try to support feature mentioned at  #1 

<br>

Usage:

```bash
$ time \
  OPENAI_MODEL='deepseek-chat' \
  OPENAI_API_KEY='YOUR DEEPSEEK API_KEY HERE' \
  OPENAI_API_URL='https://api.deepseek.com/v1/chat/completions'  \
  ./howto  find files modified today 

real	0m4.977s
```

it works,  
  but response slow..